### PR TITLE
Simplify reporting to highest value per account

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   activesupport (~> 7.0)

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,15 @@ task :validate do
   end
 end
 
+desc <<~DESC
+  Generates CSV(s) for available data.
+
+  Parameters can be passed as env vars.
+
+  Supported parameters:
+
+    YEAR=YYYY, the year to generate a report for. Default is to generate a report for all years defined in `fatca.yml`.
+DESC
 task :generate_csv do
   strategy = ENV.fetch('STRATEGY', 'both').to_sym
 

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -50,8 +50,14 @@ module FBARPrep
       running_balance.balance_on(date, strategy)
     end
 
-    def highest_balance_date(strategy = :eod)
-      running_balance.highest_balance_date(strategy)
+    def highest_balance_date(strategy = :eod, date_range = nil)
+      running_balance.highest_balance_date(strategy, date_range)
+    end
+
+    def max_balance_and_date(date_range = nil)
+      date = highest_balance_date(:max, date_range)
+
+      [balance_on(date, :max), date]
     end
 
     def transactions

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -41,10 +41,18 @@ module FBARPrep
       :provider,
       :currency,
       :opening_date,
+      :closing_date,
       :address,
       :full_provider_name
 
     attr_reader :statements, :running_balance
+
+    def open_in?(date_range)
+      opened_in_time = opening_date < date_range.end
+      still_open = closing_date.nil? || closing_date > date_range.begin
+
+      opened_in_time && still_open
+    end
 
     def balance_on(date, strategy = :eod)
       running_balance.balance_on(date, strategy)
@@ -94,7 +102,6 @@ module FBARPrep
       def_delegators :@account_record,
         :number,
         :sort_code,
-        :closing_date,
         :joint
 
       def identifier

--- a/lib/fbar_tax_year/requirement_calculator.rb
+++ b/lib/fbar_tax_year/requirement_calculator.rb
@@ -24,7 +24,8 @@ module FBARPrep
         end_of_year = Date.new(year, 12, 31)
         date_range = (Date.new(year, 1, 1)..end_of_year)
 
-        return accounts.map do |account|
+        return accounts.filter {|a| a.open_in?(date_range)}
+          .map do |account|
           # Check the last day of the year.
           #
           # If the account was opened during the year, there will be a balance.

--- a/lib/fbar_tax_year/requirement_calculator.rb
+++ b/lib/fbar_tax_year/requirement_calculator.rb
@@ -7,8 +7,6 @@ module FBARPrep
     class RequirementCalculator
       REPORTING_THRESHOLD = ::Money.from_amount(10_000, "USD")
 
-      class InconsistentDataError < StandardError; end
-
       def initialize(fbar_year, accounts, strategy: :both)
         raise 'bad strategy' unless [ :both, :eod, :max ].include?(strategy)
 
@@ -23,46 +21,10 @@ module FBARPrep
       def report_data
         year = fbar_year.year
 
-        balances = (Date.new(year, 1, 1)..Date.new(year, 12, 31)).map do |date|
-          {
-            date:,
-            eod_balance: sum_balances(accounts.map {|account| account.balance_on(date)}.compact),
-            max_balance: sum_balances(accounts.map {|account| account.balance_on(date, :max)}.compact)
-          }
-        end
-
-        highest_eod = balances.max_by {|h| h[:eod_balance]}
-        date_of_highest_eod_balance = highest_eod[:date]
-
-        highest_max = balances.max_by {|h| h[:max_balance]}
-        date_of_highest_max_balance = highest_max[:date]
-
         end_of_year = Date.new(year, 12, 31)
+        date_range = (Date.new(year, 1, 1)..end_of_year)
 
-        data = [
-          {
-            'year' => year,
-            'bank name' => nil,
-            'bank address' => nil,
-            'account' => nil,
-            'account currency' => nil,
-            'exchange rate to USD' => nil,
-            'fbar threshold (USD)' => REPORTING_THRESHOLD.to_f,
-            'highest combined eod balance' => float_or_nil(highest_eod[:eod_balance]),
-            'date of highest combined eod balance' => strdate(date_of_highest_eod_balance),
-            'highest combined max balance' => float_or_nil(highest_max[:max_balance]),
-            'date of highest combined max balance' => strdate(date_of_highest_max_balance),
-
-            'balance at eoy (local currency)' => nil,
-            'balance at eoy (USD)' => nil,
-            'highest eod account balance (local currency)' => nil,
-            'highest eod account balance (USD)' => nil,
-            'highest max account balance (local currency)' => nil,
-            'highest max account balance (USD)' => nil,
-          }
-        ]
-
-        accounts.each do |account|
+        return accounts.map do |account|
           # Check the last day of the year.
           #
           # If the account was opened during the year, there will be a balance.
@@ -70,18 +32,19 @@ module FBARPrep
           # have to report the EOY balance.
           next unless account.balance_available?(end_of_year)
 
-          data.push({
-            'year' => year,
+          max_balance, max_balance_date = account.max_balance_and_date(date_range)
+
+          {
             'bank name' => account.full_provider_name,
             'bank address' => account.address,
             'account' => account.identifier,
             'account currency' => account.currency,
             'exchange rate to USD' => exchange_rate_to_usd(account.currency),
-            'fbar threshold (USD)' => nil,
-            'highest combined eod balance' => nil,
-            'date of highest combined eod balance' => nil,
-            'highest combined max balance' => nil,
-            'date of highest combined max balance' => nil,
+            'fbar threshold (USD)' => REPORTING_THRESHOLD.to_f,
+
+            'maximum balance (local currency)' => float_or_nil(max_balance),
+            'maximum balance (USD)' => float_or_nil(usd(max_balance)),
+            'maximum balance date' => max_balance_date.to_s,
 
             'balance at eoy (local currency)' => float_or_nil(
               account.balance_on(end_of_year)
@@ -89,24 +52,8 @@ module FBARPrep
             'balance at eoy (USD)' => float_or_nil(
               usd(account.balance_on(end_of_year))
             ),
-            'highest eod account balance (local currency)' => float_or_nil(
-              account.balance_on(date_of_highest_eod_balance)
-            ),
-            'highest eod account balance (USD)' => float_or_nil(
-              usd(account.balance_on(date_of_highest_eod_balance))
-            ),
-            'highest max account balance (local currency)' => float_or_nil(
-              account.balance_on(date_of_highest_max_balance, :max)
-            ),
-            'highest max account balance (USD)' => float_or_nil(
-              usd(account.balance_on(date_of_highest_max_balance, :max))
-            ),
-          })
-        end
-
-        raise InconsistentDataError.new unless data.map(&:keys).uniq.size == 1
-
-        data
+          }
+        end.compact
       end
 
       def float_or_nil(value)

--- a/lib/running_balance.rb
+++ b/lib/running_balance.rb
@@ -51,18 +51,34 @@ module FBARPrep
       transactions.filter {|t| t.date == date}.map(&:balance).max
     end
 
-    def date_of_max_eod_balance(date_range)
+    def date_of_max_eod_balance(date_range = nil)
       candidates = transactions
 
-      candidates = transactions.filter {|txn| date_range.include?(txn.date)} if date_range
+      if date_range.present?
+        # Date range precedes any transaction data
+        return if candidates.all? { |txn| txn.date > date_range.end }
+
+        candidates = candidates.filter {|txn| date_range.include?(txn.date)}
+
+        # We have transactions, but none explicitly fall within our range, so we choose the beginning date.
+        return date_range.begin if candidates.empty? && !transactions.empty?
+      end
 
       candidates.group_by(&:date).values.flat_map(&:last).max_by(&:balance).date
     end
 
-    def date_of_max_balance(date_range)
+    def date_of_max_balance(date_range = nil)
       candidates = transactions
 
-      candidates = transactions.filter {|txn| date_range.include?(txn.date)} if date_range
+      if date_range.present?
+        # Date range precedes any transaction data
+        return if candidates.all? { |txn| txn.date > date_range.end }
+
+        candidates = candidates.filter {|txn| date_range.include?(txn.date)}
+
+        # We have transactions, but none explicitly fall within our range, so we choose the beginning date.
+        return date_range.begin if candidates.empty? && !transactions.empty?
+      end
 
       candidates.max_by(&:balance).date
     end


### PR DESCRIPTION
A previous version of this tool was based on a misunderstanding that the reporting requirement was for:

> the balance in each account on the date of the highest combined total balance across all accounts.

I have since been informed that the requirement is just to report the highest balance in each account by a tax
professional.

This change simplifies the CSV outputs, and also improves the date clamping mechanisms for balance queries.
